### PR TITLE
insert() fixed on Android 10 and new SQLCipher version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,5 +36,5 @@ android {
 
 dependencies {
     // See: https://www.zetetic.net/sqlcipher/sqlcipher-for-android/
-    compile 'net.zetetic:android-database-sqlcipher:4.0.0@aar'
+    compile 'net.zetetic:android-database-sqlcipher:4.2.0@aar'
 }

--- a/android/src/main/java/com/github/drydart/flutter_sqlcipher/SQLiteDatabaseHandler.java
+++ b/android/src/main/java/com/github/drydart/flutter_sqlcipher/SQLiteDatabaseHandler.java
@@ -445,9 +445,44 @@ class SQLiteDatabaseHandler extends FlutterMethodCallHandler {
   convertMapToContentValues(final Map<String, Object> input) {
     assert(input != null);
 
-    final Parcel parcel = Parcel.obtain();
-    parcel.writeMap(input);
-    parcel.setDataPosition(0);
-    return ContentValues.CREATOR.createFromParcel(parcel);
+    ContentValues cv = new ContentValues(input.size());
+    for (String key : input.keySet()) {
+      Object value = input.get(key);
+
+      if (value == null) {
+        cv.putNull(key);
+      }
+      else if (value instanceof Boolean) {
+        cv.put(key, (Boolean)value);
+      }
+      else if (value instanceof Byte) {
+        cv.put(key, (Byte)value);
+      }
+      else if (value instanceof Short) {
+        cv.put(key, (Short)value);
+      }
+      else if (value instanceof Integer) {
+        cv.put(key, (Integer)value);
+      }
+      else if (value instanceof Long) {
+        cv.put(key, (Long)value);
+      }
+      else if (value instanceof Double) {
+        cv.put(key, (Double)value);
+      }
+      else if (value instanceof Float) {
+        cv.put(key, (Float)value);
+      }
+      else if (value instanceof String) {
+        cv.put(key, (String)value);
+      }
+      else if (value instanceof byte[]) {
+        cv.put(key, (byte[])value);
+      }
+      else {
+        throw new IllegalArgumentException("Unsupported class type " + value.getClass() + " for key " + key);
+      }
+    }
+    return cv;
   }
 }

--- a/android/src/main/java/com/github/drydart/flutter_sqlcipher/SQLiteDatabaseHandler.java
+++ b/android/src/main/java/com/github/drydart/flutter_sqlcipher/SQLiteDatabaseHandler.java
@@ -446,8 +446,9 @@ class SQLiteDatabaseHandler extends FlutterMethodCallHandler {
     assert(input != null);
 
     ContentValues cv = new ContentValues(input.size());
-    for (String key : input.keySet()) {
-      Object value = input.get(key);
+    for (final Map.Entry<String,Object> entry : input.entrySet()) {
+      final String key = entry.getKey();
+      final Object value = entry.getValue();
 
       if (value == null) {
         cv.putNull(key);


### PR DESCRIPTION
This commit fix two issues.

First of all, the _insert()_ method was broken on my Pixel 2 XL with the Android 10 update. The _convertMapToContentValues()_ method always returned _null_. I fixed it by filling the _ContentValues_ explicitly instead of relying on a _Parcel_. I think this may be a little slower, but at least it works.

I also changed the SQLCipher version to the 4.2.0 to get rid of [an annoying log](https://discuss.zetetic.net/t/android-4-0-2-release/3467).